### PR TITLE
add faq about dockIcon and full-screen

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -43,6 +43,14 @@ hs.fnutils.each(hs.application.runningApplications(), function(app) print(app:ti
 
 Many macOS applications (e.g. Emacs, IBM Notes, Adium) mark their menus as disabled when their windows lose focus, so you may find that you can't play with them from the Hammerspoon Console. Your only option here is to encode the actions in your init.lua or bind them to events (such as hotkeys) from the console, then transfer focus back to the application window.
 
+<h2>Issues with full-screen applications</h2>
+<h3>No graphical/UI elements appear when an application is in full-screen mode</h3>
+This is known to happen when running Hammerspoon with the Dock icon enabled. Try unchecking the "Show dock icon" option in the Hammerspoon Preferences, or add the following code to your <code>init.lua</code> file:
+
+<pre>
+hs.dockIcon(false)
+</pre>
+
 <h2>Can I donate money to Hammerspoon's developers?</h2>
 
 <p>That is a tremendously generous thought, which we appreciate very much. However, we've taken the view that we would rather keep working on Hammerspoon for fun and not feel obligated to work on it because of money.</p>


### PR DESCRIPTION
I spent months not being able to use window hints or my Seal searchbar atop a full-screen application. Then I discovered [issue 1184](https://github.com/Hammerspoon/hammerspoon/issues/1184) and realized all I had to do was disable the Hammerspoon dock icon.

A recent Hammerspoon release changes the default setting to *not* have a dock icon, which will probably cut down on the number of people that run into this issue. But nevertheless I wanted to document this somewhere more obvious for people.

Let me know if there is a better place to put this.