### PR TITLE
Changing OS X to macOS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Hammerspoon
 email: cmsj@tenshu.net
 description: > # this means to ignore newlines until "baseurl:"
-  Staggeringly powerful OS X desktop automation with Lua. Making the runtime, funtime.
+  Staggeringly powerful macOS desktop automation with Lua. Making the runtime, funtime.
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://hammerspoon.github.io" # the base hostname & protocol for your site
 twitter_username: _hammerspoon


### PR DESCRIPTION
Came across this app today and noticed this when sharing the link in Slack. Apple renamed "OS X" to "macOS" at WWDC 4 years ago. Just a little housekeeping.