### PR TITLE
Fix documentation "Using a Spoon"

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -97,7 +97,6 @@ Installing a Spoon doesn't mean it's going to run by default, so we'll now add s
 
 ```lua
 hs.loadSpoon("AClock")
-spoon.AClock:init()
 hs.hotkey.bind({"cmd", "alt", "ctrl"}, "C", function()
   spoon.AClock:toggleShow()
 end)


### PR DESCRIPTION
The `init()` method is called automatically after loading a spoon, so it doesn't need to (or even should not) be called by the user of a spoon.