### PR TITLE
docs(fix): update to a cleaner fancy reload

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -364,17 +364,14 @@ The following snippet introduces another new extension, `pathwatcher` which will
 
 ```lua
 function reloadConfig(files)
-    doReload = false
-    for _,file in pairs(files) do
-        if file:sub(-4) == ".lua" then
-            doReload = true
+    for _, v in ipairs(files) do
+        if v:match("%.lua$") then
+            hs.reload()
+            return
         end
     end
-    if doReload then
-        hs.reload()
-    end
 end
-myWatcher = hs.pathwatcher.new(os.getenv("HOME") .. "/.hammerspoon/", reloadConfig):start()
+myWatcher = hs.pathwatcher.new(hs.configdir, reloadConfig):start()
 hs.alert.show("Config loaded")
 ```
 


### PR DESCRIPTION
The updated version simplifies the code by using hs.configdir, ipairs, and pattern matching, calling hs.reload() immediately upon finding a matching .lua file. In contrast, the original version manually constructs the path, iterates with pairs, and sets a flag to reload after checking all files.